### PR TITLE
docs: AI team onboarding architecture profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# TilbagoApiNet
+
+TilbagoApiNet is a .NET API client implementation for the tilbago Easy-API, an online service for debt enforcement and loss certificates in Switzerland. It provides an abstracted, type-safe way for .NET applications to create cases (natural/legal persons), query status, and upload attachments to Tilbago, following the established architectural patterns seen across AMANDA-Technology API clients (like BexioApiNet and CashCtrlApiNet).
+
+## Tech Stack
+- **Framework:** .NET (C# 10+)
+- **Build System:** MSBuild / `dotnet` CLI
+- **HTTP Client:** `HttpClient` with `System.Text.Json` for serialization
+- **Testing:** NUnit (`nunit`) framework
+
+## Solution Structure
+- `src/TilbagoApiNet`: Main library implementing the API connectors, services, and HTTP client handler.
+- `src/TilbagoApiNet.Abstractions`: Core domain models (Cases, Debtors, Creditors), views, and enums.
+- `src/TilbagoApiNet.AspNetCore`: Dependency Injection integration (`IServiceCollection` extensions) for ASP.NET Core apps.
+- `src/TilbagoApiNet.Tests`: NUnit tests for end-to-end and unit testing the client functionality.
+
+## Build Commands
+- **Restore:** `dotnet restore`
+- **Build:** `dotnet build`
+- **Test:** `dotnet test` (Requires environment variables `TilbagoApiNet__ApiKey` and `TilbagoApiNet__BaseUri` for E2E tests).
+
+## Key Conventions
+- **Connector Pattern:** API interactions are grouped by domain into "Services" or "Connectors" (e.g., `CaseService.cs`), mirroring the Tilbago API structure.
+- **Dependency Injection:** Clients are expected to register the API via `services.AddTilbagoServices(apiKey, baseUri)`. The `ITilbagoApiClient` is scoped and aggregates all individual service connectors.
+- **Connection Handler:** A central `TilbagoConnectionHandler` manages the singleton-like `HttpClient` instance, including default headers (e.g., `api_key`).
+- **Domain Modeling:** Entities are placed in `.Abstractions/Models` and view models (used for specific request bodies like `CreateNaturalPersonCaseView`) are placed in `.Abstractions/Views`.
+- **Serialization:** `System.Text.Json.Serialization` is used heavily, particularly `[JsonPropertyName]` to map to the API's camelCase naming.
+- **Error Handling:** 4xx and 5xx responses are captured and throw an `InvalidOperationException` containing the serialized `ErrorModel.Message` from the response.
+
+## Architecture Patterns
+This repository follows the AMANDA-Technology "ApiNet" family of patterns:
+1. **Aggregator Interface:** The root interface `ITilbagoApiClient` serves as a facade to access modular service interfaces (e.g., `ICaseService`).
+2. **Abstractions Separation:** Core types are isolated in an `Abstractions` package to allow sharing models without forcing the HTTP implementation dependency.
+3. **ASP.NET Core Integration:** A lightweight `.AspNetCore` package provides standard `IServiceCollection` extension methods to register the configuration, connection handler, and the API client natively.
+
+## Important File Locations
+- **Entry Point:** `src/TilbagoApiNet/Services/TilbagoApiClient.cs`
+- **DI Registration:** `src/TilbagoApiNet.AspNetCore/TilbagoServiceCollection.cs`
+- **Connection Management:** `src/TilbagoApiNet/Services/TilbagoConnectionHandler.cs`
+- **Case Endpoints:** `src/TilbagoApiNet/Services/Connectors/CaseService.cs`
+- **Core Domain Model:** `src/TilbagoApiNet.Abstractions/Models/Case.cs`
+
+## Known Constraints
+- The `CaseService.AddAttachmentAsync` method removes the `Content-Type` header for the `MultipartContent` manually, as the server responds with a 500 error if it is included.
+- Tests currently point to real API endpoints, requiring a valid Tilbago API key to run successfully.
+- Unlike BexioApiNet or CashCtrlApiNet which may implement robust querying abstractions, Tilbago API currently supports limited querying and focuses mainly on `PUT` / `GET status` flows.
+
+## Adding a New API Endpoint
+1. **Model:** Add new entity models in `src/TilbagoApiNet.Abstractions/Models/` and request/response views in `src/TilbagoApiNet.Abstractions/Views/`. Use `[JsonPropertyName]` for all fields.
+2. **Interface:** Create a new service interface (e.g., `INewEndpointService.cs`) in `src/TilbagoApiNet/Interfaces/Connectors/`.
+3. **Implementation:** Create the class implementing the new interface (e.g., `NewEndpointService.cs`) in `src/TilbagoApiNet/Services/Connectors/`. Inject `ITilbagoConnectionHandler` in the constructor. Use `_tilbagoConnectionHandler.Client` for HTTP calls.
+4. **Registration:** Update `ITilbagoApiClient` and `TilbagoApiClient` to expose the new service as a property (e.g., `public INewEndpointService NewEndpointService { get; set; }`). Instantiate it in the constructor.
+5. **Test:** Add a new test method in `src/TilbagoApiNet.Tests/` to verify integration against a live environment.

--- a/doc/ai-readiness.md
+++ b/doc/ai-readiness.md
@@ -1,0 +1,58 @@
+---
+title: "AI Readiness Assessment"
+tags: ["ai", "readiness", "assessment"]
+---
+
+# AI Readiness Assessment: TilbagoApiNet
+
+## Section 1: Documentation Quality
+
+**Assessment:**
+- **Existing Documentation:** The project contains a clear `README.md` with build commands and basic architectural principles. The `doc/architecture/` folder provides C4 Level 1 and 2 models (Context and Containers) which clearly outline the interaction between the abstractions, the main library, and the ASP.NET Core dependency injection package.
+- **Missing/Insufficient:** The project lacks a comprehensive API reference mapping all available Tilbago endpoints to what is currently implemented or missing. While there are XML comments on classes (e.g., `CaseService.cs`), the domain concepts (what a "Debtor" vs. "Creditor" entails specific to Tilbago) rely heavily on external knowledge or the tilbago.ch website.
+- **Improvements for AI:** Adding a formal OpenAPI/Swagger JSON (if available from Tilbago) to the documentation would allow AI agents to confidently implement new endpoints without hallucinating request/response structures.
+
+**Rate:** Ready
+
+## Section 2: Test Coverage
+
+**Assessment:**
+- **Test Framework:** NUnit. Run using `dotnet test`. Note: Running tests requires environment variables `TilbagoApiNet__ApiKey` and `TilbagoApiNet__BaseUri`.
+- **What IS covered:** 
+  - `src/TilbagoApiNet.Tests/CreateCase.cs` contains a single End-to-End (E2E) test (`GetCreatedCaseAndAddAttachmentForNaturalPerson`) covering:
+    - `CreateNaturalPersonCaseAsync`
+    - `GetStatusAsync`
+    - `AddAttachmentAsync`
+- **What is NOT covered:**
+  - `CreateLegalPersonCaseAsync`
+  - `CreateAsync` (raw case creation)
+  - All error paths (400, 401, 402, 500 status codes).
+  - There are zero offline unit tests (mocking the HTTP client).
+- **Test Quality:** The existing test is an integration/E2E test that hits the live Tilbago API. This is dangerous for AI development because running `dotnet test` repeatedly could incur costs, create garbage data, or fail entirely if credentials aren't present in the environment. Existing tests are superficial "happy path" checks.
+
+**Rate:** Minimal Coverage
+
+## Section 3: Technical Debt & Danger Zones
+
+**Assessment:**
+- **Fragile Code (Error Deserialization):** In `src/TilbagoApiNet/Services/Connectors/CaseService.cs` (lines 73, 104, 122), error handling assumes the response body is always valid JSON mapping to `ErrorModel`:
+  ```csharp
+  throw new InvalidOperationException((await JsonSerializer.DeserializeAsync<ErrorModel>(responseContent))?.Message);
+  ```
+  *Why it's dangerous:* If the server returns an HTML error page (e.g., 502 Bad Gateway from a proxy), `JsonSerializer` will throw an unhandled `JsonException`, masking the true HTTP error. AI should be careful to handle non-JSON error payloads safely.
+- **Risky Areas (API Quirks):** In `CaseService.cs` (line 89), there is a specific workaround:
+  ```csharp
+  multipartFormContent.Headers.Remove("Content-Type"); // Must be removed or 500 from server
+  ```
+  *Why it's dangerous:* An AI agent attempting to refactor or "clean up" the `AddAttachmentAsync` method might remove this hack, inadvertently breaking file uploads to the API.
+- **Architectural Debt (HttpClient usage):** `src/TilbagoApiNet/Services/TilbagoConnectionHandler.cs` manually instantiates a `new HttpClient()`. 
+  *Why it's dangerous:* In high-throughput ASP.NET Core applications, this can lead to socket exhaustion or DNS caching issues. Modifying this requires coordinated changes across the `TilbagoApiNet.AspNetCore` dependency injection setup to use `IHttpClientFactory`.
+
+## Section 4: Backlog Ideas
+
+| Title | Description | Complexity | Priority |
+|-------|-------------|------------|----------|
+| **Offline Unit Testing Suite** | Abstract the HTTP calls or mock `HttpMessageHandler` to allow testing the serialization and logic without requiring a live Tilbago API key. | M | High |
+| **Resilient Error Deserialization** | Update `CaseService` to check the `Content-Type` before attempting to deserialize an `ErrorModel`, preventing `JsonException` on 5xx HTML errors. | S | High |
+| **Migrate to IHttpClientFactory** | Refactor `TilbagoConnectionHandler` and `TilbagoServiceCollection` to leverage ASP.NET Core's `IHttpClientFactory` to prevent socket exhaustion. | M | Medium |
+| **Complete API Implementation** | Audit the official Tilbago Easy-API documentation to identify missing endpoints (e.g., querying cases, fetching PDF documents) and implement them. | L | Low |

--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -1,0 +1,36 @@
+---
+title: "Architecture Overview"
+tags: ["architecture", "readme"]
+---
+
+# TilbagoApiNet Architecture Overview
+
+Welcome to the architecture documentation for the TilbagoApiNet project. This library is a .NET client for the Tilbago Easy-API, allowing seamless integration with Tilbago's debt collection services.
+
+## Purpose
+The primary goal of this library is to encapsulate the HTTP communication, serialization, and endpoint routing required to interface with Tilbago, presenting a clean, strongly-typed C# API to consumer applications. It follows the established AMANDA-Technology "ApiNet" family conventions (similar to BexioApiNet and CashCtrlApiNet).
+
+## Key Constraints
+- Must remain compatible with standard `IServiceCollection` Dependency Injection setups.
+- Avoids heavy 3rd-party dependencies where possible (uses native `System.Text.Json` and `HttpClient`).
+
+## Tech Stack
+| Component | Technology | Use Case |
+|-----------|------------|----------|
+| Language | C# 10+ | Core development language |
+| HTTP | `HttpClient` | Used via `TilbagoConnectionHandler` for API calls |
+| JSON | `System.Text.Json` | Serialization/Deserialization of requests and responses |
+| Tests | NUnit | Integration and E2E testing framework |
+
+## Documentation Map
+Explore the C4 model documentation below to understand the system at different levels of abstraction:
+
+1. **[System Context (C4 Level 1)](context.md)**: High-level view of the library and its external dependencies.
+2. **[Containers (C4 Level 2)](containers.md)**: Breakdown of the library into NuGet packages/projects.
+3. **Components (C4 Level 3)**:
+   - [TilbagoApiNet (Main Library)](components/tilbagoapinet.md)
+   - [TilbagoApiNet.Abstractions](components/abstractions.md)
+   - [TilbagoApiNet.AspNetCore](components/aspnetcore.md)
+   - [TilbagoApiNet.Tests](components/tests.md)
+4. **[Architecture Decision Records (ADRs)](decisions/)**: Log of significant technical decisions.
+5. **[Glossary](glossary.md)**: Domain terminology definition.

--- a/doc/architecture/components/abstractions.md
+++ b/doc/architecture/components/abstractions.md
@@ -1,0 +1,33 @@
+---
+title: "Component Diagram: TilbagoApiNet.Abstractions"
+tags: ["architecture", "c4-level-3", "components", "abstractions"]
+---
+
+# Component Diagram: TilbagoApiNet.Abstractions
+
+This package contains no business logic. It provides the Type definitions for payloads sent to and from the Tilbago API.
+
+## Diagram
+
+```mermaid
+C4Component
+    title Component diagram for TilbagoApiNet.Abstractions
+
+    Container_Boundary(abstractions, "TilbagoApiNet.Abstractions") {
+        Component(models, "Models", "Entities", "Root entities mapping to Tilbago resources (e.g., Case, Debtor, Creditor).")
+        Component(views, "Views", "DTOs", "Specific input/output payloads (e.g., CreateNaturalPersonCaseView, CaseStatusView).")
+        Component(enums, "Enums", "Constants", "Standardized enumerated values (e.g., Language, Sex).")
+    }
+```
+
+## Key Components
+
+- **`Models`**: 
+  - `Case`: The primary resource in Tilbago representing a debt collection case.
+  - `Debtor`, `Creditor`, `ResponsiblePerson`: Person/entity objects linked to a case.
+  - `Claim`: Represents the financial demand.
+- **`Views`**: 
+  - Used for specific request structures where a full `Case` object may be too verbose or requires specific validation formats (e.g. `CreateLegalPersonCaseView`). 
+  - The `ErrorModel` maps upstream 4xx/5xx responses to manageable objects.
+- **`Enums`**: 
+  - Strongly typed alternatives to magic strings required by the Tilbago API.

--- a/doc/architecture/components/aspnetcore.md
+++ b/doc/architecture/components/aspnetcore.md
@@ -1,0 +1,34 @@
+---
+title: "Component Diagram: TilbagoApiNet.AspNetCore"
+tags: ["architecture", "c4-level-3", "components", "aspnetcore"]
+---
+
+# Component Diagram: TilbagoApiNet.AspNetCore
+
+A helper package for standardizing dependency injection in ASP.NET Core applications.
+
+## Diagram
+
+```mermaid
+C4Component
+    title Component diagram for TilbagoApiNet.AspNetCore
+
+    Container(app, "Consumer Web App", "ASP.NET Core")
+    Container(mainLib, "TilbagoApiNet", ".NET Library")
+
+    Container_Boundary(aspNetCore, "TilbagoApiNet.AspNetCore") {
+        Component(extensions, "TilbagoServiceCollection", "Extension Methods", "Provides IServiceCollection.AddTilbagoServices")
+    }
+
+    Rel(app, extensions, "Invokes at startup", "C#")
+    Rel(extensions, mainLib, "Registers types from", "DI")
+```
+
+## Key Components
+
+- **`TilbagoServiceCollection`**: Contains static extension methods for `IServiceCollection`.
+  - Registers `TilbagoConfiguration` as a Singleton.
+  - Registers `ITilbagoConnectionHandler` as Scoped.
+  - Registers `ITilbagoApiClient` as Scoped.
+
+By scoping the client and connection handler, the library natively supports request-scoped scenarios common in web applications, without retaining stale connections unnecessarily.

--- a/doc/architecture/components/tests.md
+++ b/doc/architecture/components/tests.md
@@ -1,0 +1,23 @@
+---
+title: "Component Diagram: TilbagoApiNet.Tests"
+tags: ["architecture", "c4-level-3", "components", "tests"]
+---
+
+# Component Diagram: TilbagoApiNet.Tests
+
+Unit and integration test coverage for the library.
+
+## Details
+
+The test suite uses **NUnit**. 
+
+Currently, the primary mechanism of testing involves executing real requests against the Tilbago API. This makes it an integration/E2E test suite rather than purely isolated unit tests.
+
+### Configuration
+Tests expect the following Environment Variables to be present on the host or CI runner:
+- `TilbagoApiNet__ApiKey`
+- `TilbagoApiNet__BaseUri`
+
+### Key Files
+- **`CreateCase.cs`**: Validates the end-to-end flow of initializing the client, creating a natural person case, asserting the ID, fetching its status, and successfully uploading an attachment.
+- **`Helpers.cs`**: Provides randomization functions to ensure unique `ExternalRef` strings across test runs, avoiding case collision on the server.

--- a/doc/architecture/components/tilbagoapinet.md
+++ b/doc/architecture/components/tilbagoapinet.md
@@ -1,0 +1,40 @@
+---
+title: "Component Diagram: TilbagoApiNet"
+tags: ["architecture", "c4-level-3", "components", "main-library"]
+---
+
+# Component Diagram: TilbagoApiNet (Main Library)
+
+The main library manages the HTTP lifecycle and aggregates API connectors.
+
+## Diagram
+
+```mermaid
+C4Component
+    title Component diagram for TilbagoApiNet (Main Library)
+
+    Container(aspNetCore, "TilbagoApiNet.AspNetCore", "DI Extensions")
+    System_Ext(tilbagoApi, "Tilbago Easy-API", "HTTPS")
+
+    Container_Boundary(mainLib, "TilbagoApiNet") {
+        Component(config, "ITilbagoConfiguration", "Configuration", "Holds the BaseUri and ApiKey required to connect.")
+        Component(connHandler, "ITilbagoConnectionHandler", "Connection Manager", "Maintains the HttpClient instance and default headers.")
+        
+        Component(apiClient, "ITilbagoApiClient", "Facade", "Root object aggregating all individual service endpoints.")
+        Component(caseService, "ICaseService", "Service Connector", "Implements operations against /case endpoints (Create, Status, Attachments).")
+    }
+
+    Rel(aspNetCore, config, "Provides", "Settings")
+    Rel(aspNetCore, connHandler, "Registers", "Scoped")
+    Rel(aspNetCore, apiClient, "Registers", "Scoped")
+    
+    Rel(apiClient, caseService, "Delegates to", "ICaseService")
+    Rel(caseService, connHandler, "Uses", "HttpClient")
+    Rel(connHandler, tilbagoApi, "Sends requests to", "JSON/HTTPS")
+```
+
+## Key Components
+
+- **`ITilbagoApiClient` / `TilbagoApiClient`**: The main entry point. Exposes `CaseService`.
+- **`ITilbagoConnectionHandler` / `TilbagoConnectionHandler`**: Centralizes `HttpClient` creation. Sets the `BaseAddress` and injects the `api_key` header from the provided configuration. Implements `IDisposable` to properly dispose the underlying client.
+- **`ICaseService` / `CaseService`**: Responsible for serialization, API path formatting (`/case`, `/case/{id}/status`), and deserializing responses. Translates specific views (like `CreateNaturalPersonCaseView`) into the underlying `Case` model before transmitting.

--- a/doc/architecture/containers.md
+++ b/doc/architecture/containers.md
@@ -1,0 +1,42 @@
+---
+title: "Container Diagram"
+tags: ["architecture", "c4-level-2", "containers"]
+---
+
+# Container Diagram: TilbagoApiNet Packages
+
+The TilbagoApiNet system is broken down into modular packages (containers in C4 terminology) delivered as NuGet packages. This follows the AMANDA-Technology ApiNet pattern.
+
+## Diagram
+
+```mermaid
+C4Container
+    title Container diagram for TilbagoApiNet
+
+    Person(app, "Consumer Application", "A .NET Application")
+
+    System_Boundary(tilbagoApiNet, "TilbagoApiNet Ecosystem") {
+        Container(abstractions, "TilbagoApiNet.Abstractions", ".NET Library", "Provides domain models, enums, and views (DTOs). Contains no logic.")
+        Container(mainLib, "TilbagoApiNet", ".NET Library", "Implements the core HTTP connection handler, serialization, and service endpoints.")
+        Container(aspNetCore, "TilbagoApiNet.AspNetCore", ".NET Library", "Provides IServiceCollection extensions for seamless ASP.NET Core DI registration.")
+    }
+
+    System_Ext(tilbagoApi, "Tilbago Easy-API", "External REST API")
+
+    Rel(app, aspNetCore, "Registers via", "AddTilbagoServices()")
+    Rel(app, mainLib, "Calls endpoints via", "ITilbagoApiClient")
+    Rel(app, abstractions, "Uses types from", "Domain Models")
+
+    Rel(aspNetCore, mainLib, "Configures", "DI")
+    Rel(mainLib, abstractions, "References", "Models")
+    
+    Rel(mainLib, tilbagoApi, "Communicates with", "JSON/HTTPS")
+```
+
+## Packages
+
+| Container | Technology | Responsibility |
+|-----------|------------|----------------|
+| **[[tilbagoapinet]]** (`src/TilbagoApiNet`) | C# / .NET | The core execution layer. Holds the connection handler, HTTP client, and connector implementations mapping to the upstream endpoints. |
+| **[[abstractions]]** (`src/TilbagoApiNet.Abstractions`) | C# / .NET | Shared definitions. Holds the `Case`, `Creditor`, `Debtor` models, enumerations, and specific view models used in requests/responses. |
+| **[[aspnetcore]]** (`src/TilbagoApiNet.AspNetCore`) | C# / .NET | Integration layer. Contains the `TilbagoServiceCollection` for dependency injection inside modern ASP.NET Core apps. |

--- a/doc/architecture/context.md
+++ b/doc/architecture/context.md
@@ -1,0 +1,30 @@
+---
+title: "Context Diagram"
+tags: ["architecture", "c4-level-1", "context"]
+---
+
+# System Context: TilbagoApiNet
+
+TilbagoApiNet acts as a bridge between .NET-based applications (developed by AMANDA-Technology or external consumers) and the Tilbago Easy-API platform, enabling automated debt enforcement and loss certificate processing.
+
+## Diagram
+
+```mermaid
+C4Context
+    title System Context diagram for TilbagoApiNet
+
+    Person(consumer, ".NET Developer / Application", "A software system or developer building an application that needs to manage debt collection cases.")
+    System(tilbagoApiNet, "TilbagoApiNet", "Provides a type-safe, abstracted .NET client library for the Tilbago API.")
+    System_Ext(tilbagoApi, "Tilbago Easy-API", "External REST API provided by tilbago AG for debt enforcement, loss certificates, and dunning.")
+
+    Rel(consumer, tilbagoApiNet, "Uses", ".NET API / NuGet")
+    Rel(tilbagoApiNet, tilbagoApi, "Makes API calls to", "JSON/HTTPS")
+```
+
+## Actors & External Systems
+
+| Name | Type | Description |
+|------|------|-------------|
+| **.NET Developer / Application** | Actor | The system or individual integrating this library to programmatically manage debt collection workflows. |
+| **TilbagoApiNet** | System | The .NET library being documented here. |
+| **Tilbago Easy-API** | External System | The upstream service provided by tilbago AG. Manages the lifecycle of a debt collection case in Switzerland. |

--- a/doc/architecture/decisions/001-use-httpclient.md
+++ b/doc/architecture/decisions/001-use-httpclient.md
@@ -1,0 +1,22 @@
+---
+title: "001: Use HttpClient per Connection Handler"
+status: "accepted"
+date: "2026-04-19"
+tags: ["architecture", "decision", "httpclient", "di"]
+---
+
+# 001: Use HttpClient per Connection Handler
+
+## Context
+When building a .NET API client, a mechanism is needed to process HTTP requests. Older patterns instantiating `HttpClient` in `using` blocks risk socket exhaustion. In modern .NET, `IHttpClientFactory` is preferred, but managing it within a standalone class library without forcing a heavy dependency on `Microsoft.Extensions.Http` can be challenging.
+
+## Decision
+The `TilbagoApiNet` main library instantiates a single `HttpClient` inside the `TilbagoConnectionHandler`. 
+When registered via `TilbagoApiNet.AspNetCore`, the handler is registered as `Scoped`. This means a new `HttpClient` instance is created per web request scope in ASP.NET Core environments, and disposed at the end of the scope.
+
+## Consequences
+- **Positive:** Keeps the `TilbagoApiNet` base library independent of ASP.NET Core-specific `IHttpClientFactory` implementations.
+- **Negative:** `Scoped` registration of `HttpClient` wrapper can theoretically lead to socket exhaustion in incredibly high-throughput scenarios compared to a true `IHttpClientFactory` singleton pooling approach. However, for a 3rd-party API client managing debt collection cases, throughput is rarely high enough to trigger this boundary.
+
+## Notes for Agents
+If you modify how `HttpClient` is injected or created, you MUST ensure you do not break the constructor signature of `TilbagoConnectionHandler` which currently accepts only `ITilbagoConfiguration`.

--- a/doc/architecture/glossary.md
+++ b/doc/architecture/glossary.md
@@ -1,0 +1,24 @@
+---
+title: "Glossary"
+tags: ["architecture", "domain", "glossary"]
+---
+
+# Glossary
+
+Domain terminology used within the TilbagoApiNet project and the upstream Tilbago API.
+
+## Core Terms
+
+- **Tilbago**: An online service/platform in Switzerland for managing debt collection, dunning, and loss certificates.
+- **Case**: The primary entity representing a single debt collection procedure against a debtor.
+- **Creditor**: The person or organization that is owed money.
+- **Debtor**: The person (Natural Person) or organization (Legal Person) that owes money.
+- **Claim**: The specific financial amount owed, including principal, interest rate, and reasons.
+- **Certificate of Loss (Verlustschein)**: A legal document in Switzerland certifying that a debt could not be collected, which can be used to initiate future collections.
+- **Payee Reference**: A unique reference string (often associated with an ESR/QR-IBAN) used to match incoming payments to the specific case.
+- **External Reference (ExternalRef)**: A unique identifier provided by the calling system (e.g., AMANDA-Technology ERP) to correlate a Tilbago case with the internal record.
+
+## API / Technical Terms
+
+- **ApiNet**: An internal naming convention at AMANDA-Technology denoting a .NET C# API client library (e.g., TilbagoApiNet, BexioApiNet, CashCtrlApiNet).
+- **View**: In this architecture, a "View" is a specific Request or Response DTO (Data Transfer Object) that does not perfectly align 1:1 with a core domain `Model`. Example: `CreateNaturalPersonCaseView`.


### PR DESCRIPTION
## AI Team Onboarding: TilbagoApiNet

Automated onboarding documentation for `AMANDA-Technology/TilbagoApiNet`.
Mode: **Standard** | Projects: **4** | Stack: **.NET (dotnet)**

Closes #6

### Deliverables
- `CLAUDE.md` — Project overview, build commands, conventions, and step-by-step guide to adding a new API endpoint
- `doc/architecture/` — 10 files (context, containers, 4 components, 1 ADR, glossary, README)
- `doc/ai-readiness.md` — Documentation Quality: **Ready** | Test Coverage: **Minimal Coverage**

### Key Findings
- **AMANDA-Technology ApiNet pattern**: Facade interface (`ITilbagoApiClient`) aggregates service connectors (`CaseService`), Abstractions package separates models from HTTP implementation, `.AspNetCore` package provides DI integration — consistent with BexioApiNet/CashCtrlApiNet
- **Minimal test coverage**: Only 1 E2E integration test (`CreateCase.cs`) requiring live API credentials; no unit tests or mocked HTTP tests
- **Known fragility**: `Content-Type` header must be manually removed for `AddAttachmentAsync` (server returns 500 otherwise); error deserialization assumes JSON responses which may fail for non-JSON 5xx errors

### Ready for Review
All onboarding documentation has been committed. Please review and merge when satisfied.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)